### PR TITLE
Fix installation check for mssqlpwner

### DIFF
--- a/linWinPwn.sh
+++ b/linWinPwn.sh
@@ -5776,7 +5776,7 @@ config_menu() {
         if [ ! -x "${ldapnomnom}" ]; then echo -e "${RED}[-] ldapnomnom is not executable${NC}"; else echo -e "${GREEN}[+] ldapnomnom is executable${NC}"; fi
         if [ ! -f "${godap}" ]; then echo -e "${RED}[-] godap is not installed${NC}"; else echo -e "${GREEN}[+] godap is installed${NC}"; fi
         if [ ! -x "${godap}" ]; then echo -e "${RED}[-] godap is not executable${NC}"; else echo -e "${GREEN}[+] godap is executable${NC}"; fi
-        if [ ! -f "${mssqlpwner }" ]; then echo -e "${RED}[-] mssqlpwner  is not installed${NC}"; else echo -e "${GREEN}[+] mssqlpwner  is installed${NC}"; fi
+        if [ ! -f "${mssqlpwner}" ]; then echo -e "${RED}[-] mssqlpwner is not installed${NC}"; else echo -e "${GREEN}[+] mssqlpwner is installed${NC}"; fi
         config_menu
         ;;
 


### PR DESCRIPTION
Prevents error:

```
[Config menu] Please choose from the following options:
------------------------------------------------------
1) Check installation of tools and dependencies
2) Synchronize time with Domain Controller (requires root)
3) Add Domain Controller's IP and Domain to /etc/hosts (requires root)
4) Update resolv.conf to define Domain Controller as DNS server (requires root)
5) Update krb5.conf to define realm and KDC for Kerberos (requires root)
6) Download default username and password wordlists (non-kali machines)
7) Change users wordlist file
8) Change passwords wordlist file
9) Change attacker's IP
10) Switch between LDAP (port 389) and LDAPS (port 636)
11) Show session information
back) Go back to Init Menu
exit) Exit
> 1

[+] impacket's findDelegation is installed
[+] impacket's GetUserSPNs is installed
[+] impacket's secretsdump is installed
[+] impacket's GetNPUsers is installed
[+] impacket's getTGT is installed
[+] impacket's goldenPac is installed
[+] impacket's rpcdump is installed
[+] impacket's reg is installed
[+] impacket's ticketer is installed
[+] impacket's getST is installed
[+] impacket's raiseChild is installed
[+] impacket's changepasswd is installed
[+] impacket's describeticket is installed
[+] bloodhound is installed
[+] ldapdomaindump is installed
[+] netexec is installed
[+] john is installed
[+] smbmap is installed
[+] nmap is installed
[+] adidnsdump is installed
[+] certi_py is installed
[+] certipy is installed
[+] ldeep is installed
[+] pre2k is installed
[+] certsync is installed
[+] windapsearch is installed
[+] windapsearch is executable
[+] enum4linux-ng is installed
[+] enum4linux-ng is executable
[+] kerbrute is installed
[+] kerbrute is executable
[+] targetedKerberoast is installed
[+] targetedKerberoast is executable
[+] CVE-2022-33679 is installed
[+] CVE-2022-33679 is executable
[+] silenthound is installed
[+] silenthound is installed
[+] DonPAPI is installed
[+] hekatomb is installed
[+] FindUncommonShares is installed
[+] FindUncommonShares is executable
[+] ExtractBitlockerKeys is installed
[+] ExtractBitlockerKeys is executable
[+] ldapconsole is installed
[+] ldapconsole is executable
[+] pyLDAPmonitor is installed
[+] pyLDAPmonitor is executable
[+] LDAPWordlistHarvester is installed
[+] LDAPWordlistHarvester is executable
[+] rdwatool is installed
[+] manspider is installed
[+] coercer is installed
[+] bloodyad is installed
[+] aced is installed
[+] sccmhunter is installed
[+] krbjack is installed
[+] ldapper is installed
[+] orpheus is installed
[+] adalanche is installed
[+] adalanche is executable
[+] mssqlrelay is installed
[+] pygpoabuse is installed
[+] pygpoabuse is executable
[+] GPOwned is installed
[+] GPOwned is executable
[+] privexchange is installed
[+] privexchange is executable
[+] RunFinger is installed
[+] RunFinger is executable
[+] LDAPNightmare is installed
[+] LDAPNightmare is executable
[-] adPEAS is not installed
[+] breads is installed
[+] ADCheck is installed
[+] smbclientng is installed
[+] ldapnomnom is installed
[+] ldapnomnom is executable
[+] godap is installed
[+] godap is executable
./linWinPwn.sh: line 5779: ${mssqlpwner }: bad substitution
```
