### PR TITLE
Prevent proxychains NetExec hangs and preserve wrapper arguments

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,13 +15,13 @@ install_dir="$(dirname "$(readlink -f "$0")")"
 # Detect Linux Distribution
 if command -v apt-get >/dev/null; then
     PKG_MANAGER="apt-get"
-    PACKAGES="python3 python3-dev python3-pip python3-venv nmap smbmap john libsasl2-dev libldap2-dev libkrb5-dev ntpsec-ntpdate wget zip unzip systemd-timesyncd pipx swig curl jq openssl rlwrap"
+    PACKAGES="python3 python3-dev python3-pip python3-venv nmap smbmap john libsasl2-dev libldap2-dev libkrb5-dev ntpsec-ntpdate wget zip unzip systemd-timesyncd pipx swig curl jq openssl rlwrap proxychains4"
 elif command -v pacman >/dev/null; then
     PKG_MANAGER="pacman"
-    PACKAGES="python python-pip python-virtualenv nmap smbmap john libsasl openldap krb5 ntp wget zip unzip systemd python-pipx swig curl jq openssl"
+    PACKAGES="python python-pip python-virtualenv nmap smbmap john libsasl openldap krb5 ntp wget zip unzip systemd python-pipx swig curl jq openssl rlwrap proxychains-ng"
 elif command -v dnf >/dev/null; then
     PKG_MANAGER="dnf"
-    PACKAGES="python3 python3-devel python3-pip nmap john curl jq openssl wget zip unzip rlwrap krb5-devel openldap-devel cyrus-sasl-devel gcc"
+    PACKAGES="python3 python3-devel python3-pip nmap john curl jq openssl wget zip unzip rlwrap krb5-devel openldap-devel cyrus-sasl-devel gcc proxychains-ng"
 else
     echo -e "${RED}[Error]${NC} Unsupported Linux distribution"
     exit 1
@@ -35,10 +35,10 @@ pipx_install_or_upgrade() {
 
 #Add to PATH
 echo -e "${BLUE}Adding "linWinPwn" to PATH ...${NC}"
-echo -e "rlwrap -Nn ${install_dir}/linWinPwn.sh \$@" | sudo tee "/usr/local/sbin/linWinPwn"
+echo -e "rlwrap -Nn ${install_dir}/linWinPwn.sh \"\$@\"" | sudo tee "/usr/local/sbin/linWinPwn"
 sudo chmod 755 /usr/local/sbin/linWinPwn
 echo -e "${BLUE}Adding "linWinPwn_proxychains" to PATH ...${NC}"
-echo -e "rlwrap -Nn proxychains -q ${install_dir}/linWinPwn.sh --dns-tcp \$@" | sudo tee "/usr/local/sbin/linWinPwn_proxychains"
+echo -e "rlwrap -Nn proxychains -q ${install_dir}/linWinPwn.sh --dns-tcp \"\$@\"" | sudo tee "/usr/local/sbin/linWinPwn_proxychains"
 sudo chmod 755 /usr/local/sbin/linWinPwn_proxychains
 sudo chmod +x ${install_dir}/linWinPwn.sh
 

--- a/linWinPwn.sh
+++ b/linWinPwn.sh
@@ -418,9 +418,15 @@ run_command() {
         if [ -n "${netexec}" ] && [[ "$*" == *"${netexec}"* ]] && [ "${cmd_timeout}" != "0" ] \
             && { [ -n "${cmd_timeout}" ] || [[ "${LD_PRELOAD}" == *proxychains* ]]; }; then
             local to="${cmd_timeout:-1800}"
-            timeout -k 30 "${to}" /usr/bin/script -qc "$@" /dev/null
+            # Keep script in the foreground process group so its terminal setup does
+            # not get stopped by SIGTTOU before netexec can start.
+            timeout --foreground -k 30 "${to}" /usr/bin/script -qc "$@" /dev/null
             local rc=$?
-            [ "$rc" -eq 124 ] && echo -e "${RED}[-] netexec command timed out (${to}s) - continuing${NC}" > /dev/tty
+            # timeout returns 124 after a normal expiry and 137 if the kill-after
+            # grace period expires and it has to escalate to SIGKILL.
+            if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+                echo -e "${RED}[-] netexec command timed out (${to}s) - continuing${NC}" > /dev/tty
+            fi
             return $rc
         else
             /usr/bin/script -qc "$@" /dev/null

--- a/linWinPwn.sh
+++ b/linWinPwn.sh
@@ -409,8 +409,23 @@ run_command() {
             echo "$(date '+%F %T'); $*" >> "$command_log"
             echo -e "${YELLOW}[i]${NC} Running command: $*" > /dev/tty
         fi
-        /usr/bin/script -qc "$@" /dev/null
-        return $?
+        # A netexec run proxied through proxychains can wedge (stuck worker holding the
+        # PTY that 'script' waits on), hanging the whole run so it never returns to the
+        # menu. Apply a per-command timeout, but only to netexec and only when proxied
+        # (the linWinPwn_proxychains wrapper sets LD_PRELOAD via 'proxychains -q'), so
+        # interactive consoles (smbclient/mssqlclient/wmiexec/...) are never killed.
+        # Override the duration with cmd_timeout=<seconds>; disable with cmd_timeout=0.
+        if [ -n "${netexec}" ] && [[ "$*" == *"${netexec}"* ]] && [ "${cmd_timeout}" != "0" ] \
+            && { [ -n "${cmd_timeout}" ] || [[ "${LD_PRELOAD}" == *proxychains* ]]; }; then
+            local to="${cmd_timeout:-1800}"
+            timeout -k 30 "${to}" /usr/bin/script -qc "$@" /dev/null
+            local rc=$?
+            [ "$rc" -eq 124 ] && echo -e "${RED}[-] netexec command timed out (${to}s) - continuing${NC}" > /dev/tty
+            return $rc
+        else
+            /usr/bin/script -qc "$@" /dev/null
+            return $?
+        fi
     else
         echo -e "${YELLOW}[i]${NC} Printing command: $*" > /dev/tty
     fi


### PR DESCRIPTION
## Summary

This change stabilizes NetExec commands launched through `linWinPwn_proxychains`, preserves command line arguments passed through the installed wrappers, and installs the runtime packages required by those wrappers.

The main issue occurred when a proxied NetExec worker remained attached to the pseudo-terminal created by `script(1)`. `run_command` continued waiting for that pseudo-terminal session, which prevented linWinPwn from returning to its menu or advancing through an automatic run.

## Root cause

linWinPwn executes tools through:

```bash
/usr/bin/script -qc "$@" /dev/null
```

The pseudo-terminal supplied by `script` supports formatted and interactive tool output. Under ProxyChains, NetExec can leave a worker or connection path active after the primary operation has completed. The pseudo-terminal remains open in this state, so `script` continues waiting and `run_command` never returns.

A timeout around `script` provides a bounded recovery path for this condition. GNU `timeout` creates a separate process group by default. When launched from the noninteractive linWinPwn shell, that process group does not own the controlling terminal. `script` performs terminal setup as it starts, and the kernel can stop it with `SIGTTOU` because its process group is outside the terminal foreground.

This produced a second failure mode during development. A healthy NetExec command that completed directly in approximately 2.4 seconds entered the stopped process state when wrapped by `timeout` and `script`. It then remained stopped until the configured timeout expired. With the default value of 1800 seconds, each proxied NetExec invocation could pause the run for 30 minutes.

## Timeout handling

The timeout invocation now uses:

```bash
timeout --foreground -k 30 "${to}" /usr/bin/script -qc "$@" /dev/null
```

`--foreground` keeps `script` attached to the controlling terminal foreground process group. This allows terminal initialization and NetExec execution to proceed normally.

The timeout remains narrowly scoped to NetExec commands when ProxyChains is active. The resolved NetExec executable path is checked against the command, and ProxyChains is detected through the `LD_PRELOAD` value established by the wrapper.

Interactive console commands such as SMB clients, MSSQL clients, WMI execution tools, and similar utilities continue through the original `script` execution path.

The timeout duration defaults to 1800 seconds. Operators can configure it through:

```bash
cmd_timeout=<seconds> linWinPwn_proxychains ...
```

A value of `cmd_timeout=0` disables this timeout.

GNU `timeout` can return two relevant statuses:

- `124` when the configured duration expires
- `137` when the kill-after grace period expires and termination escalates to `SIGKILL`

Both statuses now produce a visible timeout message before linWinPwn continues. This gives the operator a clear reason for the interrupted command and avoids silent continuation after forced termination.

## Wrapper argument handling

The generated `linWinPwn` and `linWinPwn_proxychains` wrappers now pass arguments using quoted `"$@"`.

This preserves each original argument as a distinct value. Passwords, output paths, and other values containing spaces, wildcard characters, or shell-sensitive text reach linWinPwn with their original boundaries.

## Runtime dependencies

The installer now includes the commands used by the generated wrappers:

- Debian and Ubuntu install `proxychains4`
- Arch Linux installs `proxychains-ng` and `rlwrap`
- Fedora installs `proxychains-ng`

The existing Debian, Ubuntu, and Fedora package lists already include `rlwrap` where required.

## Scope

The timeout applies to NetExec command strings that contain the resolved NetExec executable path and satisfy either of these conditions:

- ProxyChains is active through `LD_PRELOAD`
- The operator explicitly supplies `cmd_timeout`

The remaining tools retain their existing execution behavior. This keeps long-running interactive sessions under operator control.

## Validation

The changes were tested against a live SMB target through a local SOCKS5 proxy.

Validation included:

- Running NetExec directly through the supplied ProxyChains configuration
- Authenticating successfully to the SMB target
- Running the complete patched linWinPwn authentication path through ProxyChains
- Capturing successful NetExec authentication output
- Returning to the interactive main menu before the configured timeout
- Exercising a forced timeout through the actual `run_command` implementation
- Confirming exit status 124 produces the continuation message
- Confirming exit status 137 produces the continuation message
- Confirming the forced-timeout child process is cleaned up
- Auditing the process table for remaining NetExec, `script`, and test processes
- Verifying wrapper arguments containing spaces and wildcard characters
- Running `bash -n` against `install.sh` and `linWinPwn.sh`
- Running `git diff --check`
- Confirming the branch base matches the current upstream `main`
